### PR TITLE
Add support for PostgreSQL and migrations with Lapis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ build
 *.bsp
 server.cfg
 sv_resources.lua
+
+# Lapis
+*_temp
+logs
+*.compiled

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ serve as the FastDL endpoint.
 | Name          | Description                                        |
 |---------------|----------------------------------------------------|
 | `console`     | Attach to the SRCDS console. Detach with `ctrl-d`. |
+| `manage`      | Run a Lapis command line tool.                     |
 | `server`      | Start SRCDS.                                       |
 | `sync-fastdl` | Push FastDL artifacts to S3.                       |
 | `sync-maps`   | Pull map files from from S3.                       |

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,14 @@
 version: "2.4"
 services:
+  database:
+    ports:
+      - 5432:5432
+
   garrysmod:
     ports:
       - 27015:27015
       - 27015:27015/udp
+
+  lapis:
+    ports:
+      - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,17 @@
 version: "2.4"
 services:
+  database:
+    image: postgres:12.2
+    environment:
+      - POSTGRES_DB=zombiesurvival
+      - POSTGRES_PASSWORD=zombiesurvival
+      - POSTGRES_USER=zombiesurvival
+    healthcheck:
+      test: pg_isready -U zombiesurvival
+      interval: 3s
+      timeout: 3s
+      retries: 3
+
   garrysmod:
     image: zs
     build:
@@ -8,6 +20,9 @@ services:
     volumes:
       - ./src/garrysmod/cfg/server.cfg:/var/lib/steam/.steam/SteamApps/common/GarrysModDS/garrysmod/cfg/server.cfg:ro
       - ./src/garrysmod/gamemodes/zombiesurvival:/var/lib/steam/.steam/SteamApps/common/GarrysModDS/garrysmod/gamemodes/zombiesurvival:ro
+    depends_on:
+      database:
+        condition: service_healthy
     command:
       - -game garrysmod
       - -maxplayers 16
@@ -16,6 +31,25 @@ services:
       - +sv_setsteamaccount ${STEAM_GSLT}
     stdin_open: true
     tty: true
+
+  lapis:
+    image: lapis
+    build:
+      context: ./src/lapis
+      dockerfile: Dockerfile
+    environment:
+      - POSTGRES_HOST=database
+      - POSTGRES_USER=zombiesurvival
+      - POSTGRES_PASSWORD=zombiesurvival
+      - POSTGRES_DB=zombiesurvival
+      - PORT=8080
+    depends_on:
+      database:
+        condition: service_healthy
+    command:
+    - server
+    volumes:
+      - ./src/lapis:/usr/local/src
 
   awscli:
     image: amazon/aws-cli:latest

--- a/scripts/manage
+++ b/scripts/manage
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${ZS_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0") [command]
+Run a Lapis command line tool.
+"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        docker-compose run --rm \
+            lapis "$@"
+    fi
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -78,5 +78,14 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     # Push FastDL artifacts to S3
     docker-compose run --rm --no-deps awscli \
       ./scripts/sync-fastdl
+
+    # Bring up PostgreSQL and Lapis in a way that respects
+    # configured service health checks.
+    docker-compose \
+      -f docker-compose.yml \
+      up -d database lapis
+
+    # Apply any outstanding Lapis migrations
+    ./scripts/manage migrate
   fi
 fi

--- a/src/garrysmod/Dockerfile
+++ b/src/garrysmod/Dockerfile
@@ -8,3 +8,30 @@ RUN set -ex \
     +quit
 
 COPY cfg/mount.cfg garrysmod/cfg/mount.cfg
+
+# Switch to x64 branch
+RUN set -ex \
+    && /usr/games/steamcmd +login anonymous \
+    +app_update 4020 \
+    -beta x86-64 \
+    validate \
+    +quit
+
+USER root
+
+ENV LIBPQ_VERSION 11.7-0+deb10u1
+ENV LIBPQXX_VERSION 6.2.5-1
+
+RUN set -ex \
+    && deps=" \
+        libpq-dev=$LIBPQ_VERSION \
+        libpqxx-dev=$LIBPQXX_VERSION \
+    " \
+    && apt-get update && apt-get install -y $deps \
+    && rm -rf /var/lib/apt/lists/*
+
+USER steam
+
+COPY lua/bin/gmsv_pg_linux64.dll garrysmod/lua/bin/gmsv_pg_linux64.dll
+
+ENTRYPOINT ["/var/lib/steam/.steam/SteamApps/common/GarrysModDS/srcds_run_x64"]

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
@@ -112,6 +112,7 @@ include("zsbots/init.lua")
 
 include_library("statistics")
 
+include("sv_database.lua")
 include("sv_resources.lua")
 
 local pairs = pairs
@@ -235,6 +236,10 @@ function GM:Initialize()
 	game.ConsoleCommand("fire_dmgscale 1\n")
 	game.ConsoleCommand("mp_flashlight 1\n")
 	game.ConsoleCommand("sv_gravity 600\n")
+
+	self.Database:EstablishConnection(function(database)
+		MsgN(string.format("Connected to PostgreSQL\nProtocol Version: %s, Server Version %s", database.conn:protocol_version(), database.conn:server_version()))
+	end)
 end
 
 function GM:AddNetworkStrings()

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/sv_database.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/sv_database.lua
@@ -1,0 +1,32 @@
+require "pg"
+
+local database = CreateConVar("postgres_db", "zombiesurvival", bit.bor(FCVAR_PROTECTED), "")
+local password = CreateConVar("postgres_password", "zombiesurvival", bit.bor(FCVAR_PROTECTED), "")
+local user     = CreateConVar("postgres_user", "zombiesurvival", bit.bor(FCVAR_PROTECTED), "")
+local host     = CreateConVar("postgres_host", "database", bit.bor(FCVAR_PROTECTED), "")
+
+GM.Database = GM.Database or {}
+
+function GM.Database:EstablishConnection(onConnected)
+    local host, user, password, port, database = host:GetString(), user:GetString(), password:GetString(), database:GetString()
+
+    if pg then
+        self.conn = pg.new_connection()
+
+        local success, err = self.conn:connect(host, user, password, database, 5432)
+
+        if success then
+            success, err = self.conn:set_encoding("UTF8")
+
+            if not success then
+                ErrorNoHalt("Failed to set connection encoding:\n", err)
+            end
+
+            if isfunction(onConnected) then onConnected(self) end
+        else
+            ErrorNoHalt("Unable to connect to the database!\n", err)
+        end
+    else
+        ErrorNoHalt("gmsv_pg has not been found.")
+    end
+end

--- a/src/lapis/Dockerfile
+++ b/src/lapis/Dockerfile
@@ -1,0 +1,30 @@
+FROM quay.io/rbreslow/lua:5.1-alpine
+
+ENV OPENRESTY_VERSION 1.17.8.2-r0
+ENV OPENRESTY_KEY_URL "http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub"
+ENV LAPIS_VERSION 1.8.1-1
+
+RUN mkdir -p /usr/local/src
+WORKDIR /usr/local/src
+
+RUN set -ex \
+    && curl -o "/etc/apk/keys/$(basename ${OPENRESTY_KEY_URL})" "${OPENRESTY_KEY_URL}" \
+    && apk add --no-cache \
+        --repository "http://openresty.org/package/alpine/v3.12/main" \
+        "openresty=${OPENRESTY_VERSION}" \
+    && mkdir -p /var/run/openresty \
+    && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
+
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+        alpine-sdk \
+        lua5.1-dev \
+        openssl \
+        openssl-dev \
+    && luarocks install lapis ${LAPIS_VERSION} \
+    && apk del .build-deps curl unzip
+
+ENTRYPOINT ["/usr/local/bin/lapis"]
+
+CMD ["server"]

--- a/src/lapis/app.lua
+++ b/src/lapis/app.lua
@@ -1,0 +1,13 @@
+local lapis = require("lapis")
+local db = require("lapis.db")
+
+local app = lapis.Application()
+
+app:get("/healthcheck", function()
+  local res = db.query("SELECT * FROM information_schema.tables WHERE table_schema = ? AND table_type = ?", "public", "BASE TABLE")
+  return {
+    json = {"OK!"}
+  }
+end)
+
+return app

--- a/src/lapis/config.lua
+++ b/src/lapis/config.lua
@@ -1,0 +1,11 @@
+local config = require "lapis.config"
+
+config("development", {
+  port = os.getenv("PORT"),
+  postgres = {
+    host = os.getenv("POSTGRES_HOST"),
+    user = os.getenv("POSTGRES_USER"),
+    password = os.getenv("POSTGRES_PASSWORD"),
+    database = os.getenv("POSTGRES_DB")
+  }
+})

--- a/src/lapis/migrations.lua
+++ b/src/lapis/migrations.lua
@@ -1,0 +1,4 @@
+local schema = require("lapis.db.schema")
+local types = schema.types
+
+return {}

--- a/src/lapis/mime.types
+++ b/src/lapis/mime.types
@@ -1,0 +1,81 @@
+types {
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    application/x-lua                     lua;
+    application/x-moonscript              moon;
+    application/x-javascript              js;
+    application/atom+xml                  atom;
+    application/rss+xml                   rss;
+
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/x-component                      htc;
+
+    image/png                             png;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/x-icon                          ico;
+    image/x-jng                           jng;
+    image/x-ms-bmp                        bmp;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    application/java-archive              jar war ear;
+    application/mac-binhex40              hqx;
+    application/msword                    doc;
+    application/pdf                       pdf;
+    application/postscript                ps eps ai;
+    application/rtf                       rtf;
+    application/vnd.ms-excel              xls;
+    application/vnd.ms-powerpoint         ppt;
+    application/vnd.wap.wmlc              wmlc;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/x-7z-compressed           7z;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-perl                    pl pm;
+    application/x-pilot                   prc pdb;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            der pem crt;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/zip                       zip;
+
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              eot;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+
+    audio/midi                            mid midi kar;
+    audio/mpeg                            mp3;
+    audio/ogg                             ogg;
+    audio/x-m4a                           m4a;
+    audio/x-realaudio                     ra;
+
+    video/3gpp                            3gpp 3gp;
+    video/mp4                             mp4;
+    video/mpeg                            mpeg mpg;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-m4v                           m4v;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asx asf;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+}

--- a/src/lapis/models.lua
+++ b/src/lapis/models.lua
@@ -1,0 +1,2 @@
+local autoload = require("lapis.util").autoload
+return autoload("models")

--- a/src/lapis/nginx.conf
+++ b/src/lapis/nginx.conf
@@ -1,0 +1,42 @@
+worker_processes ${{NUM_WORKERS}};
+error_log stderr notice;
+daemon off;
+pid logs/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+# https://github.com/leafo/lapis/issues/57
+env POSTGRES_HOST;
+env POSTGRES_USER;
+env POSTGRES_PASSWORD;
+env POSTGRES_DB;
+env PORT;
+
+http {
+  include mime.types;
+
+  server {
+    # https://stackoverflow.com/questions/35744650/docker-network-nginx-resolver
+    resolver 127.0.0.11;
+
+    listen ${{PORT}};
+    lua_code_cache ${{CODE_CACHE}};
+
+    location / {
+      default_type text/html;
+      content_by_lua_block {
+        require("lapis").serve("app")
+      }
+    }
+
+    location /static/ {
+      alias static/;
+    }
+
+    location /favicon.ico {
+      alias static/favicon.ico;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

- Add PostgreSQL service
- Build container image for [Lapis web framework](https://leafo.net/lapis/) service
- Add `scripts/manage`
- Run migrations in `scripts/update`
- Add support for [gmsv_pg](https://github.com/Meow/gmsv_pg/compare/master...rbreslow:jrb/x64?expand=1)
- Add `GM.Database` library to assist in establishing a connection to PostgreSQL via gmsv_pg

## Notes

There was a bug with the [upstream version](http://github.com/meow/gmsv_pg) of gmsv_pg that prevented it from resolving the database via the container's DNS name. Specifically, @Meow was building the PostgreSQL connection string with `hostaddr=` vs `host=`, where the former skips DNS resolution.

I tried fixing it but was having trouble compiling an `i386` variant, so I decided to target an `x86_64` architecture. I ran into even more issues with this that led me to update the version of the [gmod-module-base](https://github.com/Facepunch/gmod-module-base/tree/development) to the `development` branch. 

According to folks in the `#cpp` channel of the Garry's Mod Discord, the size of the `unsigned char _ignore_this_common_lua_header_` array in the `lua_State` struct changed in the x64 branch and hasn't been merged with `master` yet. 🤷‍♀️

I ended up making a few other organizational changes to the project as well. I haven't had an opportunity to try and reconcile everything upstream yet, so right now this repository is using a binary I compiled off my fork.

If you're seeing this Meow, thanks so much for your work, and expect to see a contribution from me sometime in the future.

See:
- https://github.com/Meow/gmsv_pg/blob/1cd36f2d94209d08ddaf2f5864831b7e9e31f3b4/pg/src/connection.hpp#L90-L93
- https://www.postgresql.org/docs/9.1/libpq-connect.html#LIBPQ-CONNECT-HOST
- https://github.com/Meow/gmsv_pg/compare/master...rbreslow:jrb/x64?expand=1

## Testing Instructions

First, run `scripts/update` and see that the migrations table is created.

```bash
$ ./scripts/update
. . .
Creating network "zs_default" with the default driver
Creating zs_database_1 ... done
Creating zs_lapis_1    ... done
Starting zs_database_1 ... done
SQL: SELECT COUNT(*) as c from pg_class where relname = 'lapis_migrations'
Notice: Table `lapis_migrations` does not exist, creating
SQL: CREATE TABLE "lapis_migrations" (
  "name" character varying(255) NOT NULL,
  PRIMARY KEY(name)
);
SQL: SELECT * from "lapis_migrations"
Ran 0 migrations
```

Next, bring up SRCDS and observe the following success message.

```bash
$ ./scripts/server
 . . .
garrysmod_1  | Connected to PostgreSQL
garrysmod_1  | Protocol Version: 3, Server Version 120002
```

In another window or tab, verify that the migrations table exists and is empty.

```bash
$ docker-compose exec database \
    psql -U zombiesurvival
psql (12.2)
Type "help" for help.

zombiesurvival=# \d
                 List of relations
 Schema |       Name       | Type  |     Owner
--------+------------------+-------+----------------
 public | lapis_migrations | table | zombiesurvival
(1 row)

zombiesurvival=# SELECT count(*) FROM lapis_migrations;
 count
-------
     0
(1 row)
```

And finally, verify that you can interact with the database from the Garry's Mod Lua state.

```bash
$ ./scripts/console
lua_run conn = GAMEMODE.Database.conn
> conn = GAMEMODE.Database.conn...
lua_run query = conn:query("SELECT version();")
> query = conn:query("SELECT version();")...
lua_run query:set_sync(true)
> query:set_sync(true)...
lua_run success, res, size = query:run()
> success, res, size = query:run()...
lua_run PrintTable(res)
> PrintTable(res)...
1:
    version = PostgreSQL 12.2 (Debian 12.2-2.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
```

