### PR TITLE
Disabled human:sigil collisions

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/entities/entities/prop_obj_sigil/shared.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/entities/prop_obj_sigil/shared.lua
@@ -54,3 +54,8 @@ function ENT:CanBeDamagedByTeam(teamid)
 
 	return teamid == TEAM_UNDEAD
 end
+
+-- Disable human collisions on sigil
+function ENT:ShouldNotCollide(ent)
+	return ent:IsPlayer() and ent:Team() == TEAM_HUMAN
+end


### PR DESCRIPTION
Resolves #7 

Humans that are killed when stood inside a Sigil will become stuck when they reanimate until either the Sigil is corrupted or they are killed.
