### PR TITLE
Replace Arsenal Crates with Sigils

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/cl_targetid.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/cl_targetid.lua
@@ -106,9 +106,13 @@ function GM:DrawSigilTargetHint(ent, fade)
 	util.ColorCopy(color_white, colTemp)
 
 	draw.SimpleTextBlur("Sigil", "ZSHUDFontSmaller", x, y, colTemp, TEXT_ALIGN_CENTER)
-	y = y + draw.GetFontHeight("ZSHUDFontSmaller") + 0
+	local fontHeight = draw.GetFontHeight("ZSHUDFontSmaller")
 
-	draw.SimpleTextBlur("Press E to teleport", "ZSHUDFontTiny", x, y, colTemp, TEXT_ALIGN_CENTER)
+	draw.SimpleTextBlur("Press E to teleport", "ZSHUDFontTiny", x, y + fontHeight, colTemp, TEXT_ALIGN_CENTER)
+
+	if self:PlayerCanPurchase(MySelf) then
+		draw.SimpleTextBlur(translate.Get("press_f2_for_the_points_shop"), "ZSHUDFontTiny", x, y + fontHeight * 1.5, colTemp, TEXT_ALIGN_CENTER)
+	end
 end
 
 GM.TraceTarget = NULL

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
@@ -3913,31 +3913,6 @@ function GM:WaveStateChanged(newstate)
 					gamemode.Call("GiveDefaultOrRandomEquipment", pl)
 				end
 			end
-
-			-- We should spawn a crate in a random spawn point if no one has any.
-			if not self.ZombieEscape and #ents.FindByClass("prop_arsenalcrate") == 0 then
-				local have = false
-				for _, pl in pairs(humans) do
-					if pl:HasWeapon("weapon_zs_arsenalcrate") then
-						have = true
-						break
-					end
-				end
-
-				if not have and #humans >= 1 then
-					local spawn = self:PlayerSelectSpawn(humans[math.random(#humans)])
-					if spawn and spawn:IsValid() then
-						local ent = ents.Create("prop_arsenalcrate")
-						if ent:IsValid() then
-							ent:SetPos(spawn:GetPos() + Vector(0, 0, 8))
-							ent:Spawn()
-							ent:DropToFloor()
-							ent:SetCollisionGroup(COLLISION_GROUP_DEBRIS_TRIGGER) -- Just so no one gets stuck in it.
-							ent.NoTakeOwnership = true
-						end
-					end
-				end
-			end
 		end
 
 		local prevwave = self:GetWave()

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/languages/english.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/languages/english.lua
@@ -28,7 +28,7 @@ LANGUAGE.nail_removed_by							= "%s removed a nail belonging to %s."
 LANGUAGE.banned_for_life_warning					= "You have the Banned for Life skill active so you can't purchase anything!"
 LANGUAGE.late_buyer_warning							= "You have the Late Buyer skill active so you can't purchase anything until the second half!"
 LANGUAGE.late_buyer_finished						= "The late buyer period has finished. You can now purchase items from the arsenal."
-LANGUAGE.need_to_be_near_arsenal_crate				= "You need to be near an Arsenal Crate to purchase items!"
+LANGUAGE.need_to_be_near_arsenal_crate				= "You need to be near a Sigil to purchase items!"
 LANGUAGE.need_to_be_near_remantler					= "You need to be near a Remantler!"
 LANGUAGE.cant_purchase_right_now					= "You can't purchase anything right now."
 LANGUAGE.dont_have_enough_points					= "You don't have enough points."
@@ -506,7 +506,7 @@ To deploy the turret, position it in a way so that the ghost is green. It must b
 <li>Use bigger props for barricades. The nails take less damage and the prop has room for more nails. In addition to that, it even acts as cover from projectiles.</li>
 </ul></p>]]
 LANGUAGE.help_cont_upgrades							= [[<p>Points are obtained through killing zombies, healing team mates, and building defenses.
-You can then exchange points in the Points Shop at Arsenal Crates.</p>
+You can then exchange points in the Points Shop at Sigils or Arsenal Crates.</p>
 
 <p>Tips for this section:
 <ul>

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend.lua
@@ -230,13 +230,20 @@ function meta:MeleeViewPunch(damage)
 end
 
 function meta:NearArsenalCrate()
+	-- Always near an arsenal crate in objective maps
+	if GAMEMODE.ObjectiveMap then
+		return true
+	end
+
 	local pos = self:EyePos()
 
 	if self.ArsenalZone and self.ArsenalZone:IsValid() then return true end
 
 	local arseents = {}
+	table.Add(arseents, ents.FindByClass("prop_obj_sigil"))
 	table.Add(arseents, ents.FindByClass("prop_arsenalcrate"))
 	table.Add(arseents, ents.FindByClass("status_arsenalpack"))
+
 
 	for _, ent in pairs(arseents) do
 		local nearest = ent:NearestPoint(pos)

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/sh_options.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/sh_options.lua
@@ -187,8 +187,6 @@ item.SkillRequirement = SKILL_U_STRENGTHSHOT
 item =
 GM:AddStartingItem("antidoteshot",		ITEMCAT_TOOLS,			40,				"weapon_zs_antidoteshot")
 item.SkillRequirement = SKILL_U_ANTITODESHOT
-GM:AddStartingItem("arscrate",			ITEMCAT_DEPLOYABLES,			50,				"weapon_zs_arsenalcrate")
-.Countables = "prop_arsenalcrate"
 GM:AddStartingItem("resupplybox",		ITEMCAT_DEPLOYABLES,			50,				"weapon_zs_resupplybox")
 .Countables = "prop_resupplybox"
 GM:AddStartingItem("remantler",			ITEMCAT_DEPLOYABLES,			50,				"weapon_zs_remantler")
@@ -264,7 +262,6 @@ GM:AddStartingItem("bloodpack",			ITEMCAT_TRINKETS,		20,				"trinket_bloodpack")
 GM:AddStartingItem("biocleanser",		ITEMCAT_TRINKETS,		20,				"trinket_biocleanser").SubCategory =			ITEMSUBCAT_TRINKETS_SPECIAL
 GM:AddStartingItem("reactiveflasher",	ITEMCAT_TRINKETS,		25,				"trinket_reactiveflasher").SubCategory =		ITEMSUBCAT_TRINKETS_SPECIAL
 GM:AddStartingItem("magnet",			ITEMCAT_TRINKETS,		25,				"trinket_magnet").SubCategory =					ITEMSUBCAT_TRINKETS_SPECIAL
-GM:AddStartingItem("arsenalpack",		ITEMCAT_TRINKETS,		55,				"trinket_arsenalpack").SubCategory =			ITEMSUBCAT_TRINKETS_SUPPORT
 GM:AddStartingItem("resupplypack",		ITEMCAT_TRINKETS,		55,				"trinket_resupplypack").SubCategory =			ITEMSUBCAT_TRINKETS_SUPPORT
 
 GM:AddStartingItem("stone",				ITEMCAT_OTHER,			10,				"weapon_zs_stone")
@@ -407,7 +404,6 @@ GM:AddPointShopItem("frotchet",			ITEMCAT_MELEE,			150,			"weapon_zs_frotchet")
 
 GM:AddPointShopItem("crphmr",			ITEMCAT_TOOLS,			25,				"weapon_zs_hammer",			nil,							nil,									nil,											function(pl) pl:GiveEmptyWeapon("weapon_zs_hammer") pl:GiveAmmo(5, "GaussEnergy") end)
 GM:AddPointShopItem("wrench",			ITEMCAT_TOOLS,			20,				"weapon_zs_wrench").NoClassicMode = true
-GM:AddPointShopItem("arsenalcrate",		ITEMCAT_DEPLOYABLES,			40,				"weapon_zs_arsenalcrate").Countables = "prop_arsenalcrate"
 GM:AddPointShopItem("resupplybox",		ITEMCAT_DEPLOYABLES,			40,				"weapon_zs_resupplybox").Countables = "prop_resupplybox"
 GM:AddPointShopItem("remantler",		ITEMCAT_DEPLOYABLES,			40,				"weapon_zs_remantler").Countables = "prop_remantler"
 GM:AddPointShopItem("msgbeacon",		ITEMCAT_DEPLOYABLES,			10,				"weapon_zs_messagebeacon").Countables = "prop_messagebeacon"
@@ -544,7 +540,6 @@ GM:AddPointShopItem("refinedsub",		ITEMCAT_TRINKETS,		50,				"trinket_refinedsub
 GM:AddPointShopItem("targetingvisiii",	ITEMCAT_TRINKETS,		50,				"trinket_targetingvisoriii").SubCategory =						ITEMSUBCAT_TRINKETS_OFFENSIVE
 GM:AddPointShopItem("eodvest",			ITEMCAT_TRINKETS,		50,				"trinket_eodvest").SubCategory =								ITEMSUBCAT_TRINKETS_DEFENSIVE
 GM:AddPointShopItem("composite",		ITEMCAT_TRINKETS,		50,				"trinket_composite").SubCategory =								ITEMSUBCAT_TRINKETS_DEFENSIVE
-GM:AddPointShopItem("arsenalpack",		ITEMCAT_TRINKETS,		50,				"trinket_arsenalpack").SubCategory =							ITEMSUBCAT_TRINKETS_SUPPORT
 GM:AddPointShopItem("resupplypack",		ITEMCAT_TRINKETS,		50,				"trinket_resupplypack").SubCategory =							ITEMSUBCAT_TRINKETS_SUPPORT
 GM:AddPointShopItem("promanifest",		ITEMCAT_TRINKETS,		50,				"trinket_promanifest").SubCategory =							ITEMSUBCAT_TRINKETS_SUPPORT
 GM:AddPointShopItem("opsmatrix",		ITEMCAT_TRINKETS,		50,				"trinket_opsmatrix").SubCategory =								ITEMSUBCAT_TRINKETS_SUPPORT


### PR DESCRIPTION
## Overview

Sigils can be used as arsenal crates, removed arsenal crates and packs from worth and shop, allow purchase anywhere in Objective maps.

Resolves #6

## Demo

![Screenshot 2020-09-15 at 14 52 14](https://user-images.githubusercontent.com/3932269/93172995-de81e100-f766-11ea-9cce-005d3bf7ee9c.png)

## Notes


I didn't increase the distance you have to be from the sigil to buy; it uses the same arsenal crate value, which requires close proximity to the sigil. 

Arsenal crates/packs are still supported b/c legacy, but have been removed from worth and shop menus.

## Testing Instructions

* Join the server as a human
* Look at a sigil after Wave 1 starts
* Hint should appear when within purchase range
* Press F2 to use the buy menu

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] README.md updated if necessary to reflect the changes
