### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+Connects #XXX
+
+## Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+## Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+* How to test this PR
+* Prefer bulleted description
+* Start after checking out this branch
+* Include any setup required, such as bundling scripts, restarting services, etc.
+* Include test case, and expected output
+
+## Checklist
+
+- [ ] `fixup!` commits have been squashed
+- [ ] README.md updated if necessary to reflect the changes


### PR DESCRIPTION
## Overview

This PR adds a [pull request template](https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository) to the repository.

I believe that a pull request template will make our work consistent and prompt for high quality testing instructions.

## Testing Instructions

There isn't a way to test until this is in the default branch for the repo.