### PR TITLE
Allow use of the hammer while barricade ghosting

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/cl_init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/cl_init.lua
@@ -75,7 +75,7 @@ function SWEP:GetViewModelPosition(pos, ang)
 		ang:RotateAroundAxis(ang:Forward(), rot.roll * power)
 	end
 
-	if owner:GetBarricadeGhosting() then
+	if self:IsOwnerBarricadeGhosting() then
 		ghostlerp = math.min(1, ghostlerp + FrameTime() * 4)
 	elseif ghostlerp > 0 then
 		ghostlerp = math.max(0, ghostlerp - FrameTime() * 5)

--- a/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/shared.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_basemelee/shared.lua
@@ -95,7 +95,7 @@ function SWEP:Reload()
 end
 
 function SWEP:CanPrimaryAttack()
-	if self:GetOwner():IsHolding() or self:GetOwner():GetBarricadeGhosting() then return false end
+	if self:GetOwner():IsHolding() or self:IsOwnerBarricadeGhosting() then return false end
 
 	return self:GetNextPrimaryFire() <= CurTime() and not self:IsSwinging()
 end
@@ -427,4 +427,8 @@ function SWEP:TranslateActivity( act )
 	end
 
 	return self.ActivityTranslate and self.ActivityTranslate[act] or -1
+end
+
+function SWEP:IsOwnerBarricadeGhosting()
+	return self:GetOwner():GetBarricadeGhosting()
 end

--- a/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/init.lua
@@ -139,7 +139,7 @@ function SWEP:SecondaryAttack()
 	end
 
 	for _, nail in pairs(ents.FindByClass("prop_nail")) do
-		if nail:GetParent() == trent and nail:GetActualPos():DistToSqr(tr.HitPos) <= 81 then
+		if nail:GetParent() == trent and nail:GetActualPos():DistToSqr(tr.HitPos) <= 8 then
 			owner:PrintTranslatedMessage(HUD_PRINTCENTER, "too_close_to_another_nail")
 			return
 		end

--- a/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/init.lua
@@ -4,7 +4,6 @@ function SWEP:Reload()
 	if CurTime() < self:GetNextPrimaryFire() then return end
 
 	local owner = self:GetOwner()
-	if owner:GetBarricadeGhosting() then return end
 
 	local tr = owner:CompensatedMeleeTrace(self.MeleeRange, self.MeleeSize)
 	local trent = tr.Entity
@@ -94,7 +93,7 @@ function SWEP:OnMeleeHit(hitent, hitflesh, tr)
 end
 
 function SWEP:SecondaryAttack()
-	if self:GetPrimaryAmmoCount() <= 0 or CurTime() < self:GetNextPrimaryFire() or self:GetOwner():GetBarricadeGhosting() then return end
+	if self:GetPrimaryAmmoCount() <= 0 or CurTime() < self:GetNextPrimaryFire() then return end
 
 	local owner = self:GetOwner()
 

--- a/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/shared.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/weapons/weapon_zs_hammer/shared.lua
@@ -57,3 +57,8 @@ end
 function SWEP:PlayRepairSound(hitent)
 	hitent:EmitSound("npc/dog/dog_servo"..math.random(7, 8)..".wav", 70, math.random(100, 105))
 end
+
+-- Disable behavior that happens when ghosting on meleebase
+function SWEP:IsOwnerBarricadeGhosting()
+	return false
+end


### PR DESCRIPTION
## Overview

This PR adjusts the minimum radius between nails and allows the user of the hammer while barricade ghosting.

Resolves #4 

## Testing Instructions

See that I am barricade ghosting through the bed and I have a bunch of nails that are less than 81 hammer units.

![image](https://user-images.githubusercontent.com/1774125/92675686-ff24e380-f2ed-11ea-9ef2-bfd874ca943c.png)
