### PR TITLE
Add JBGM License with the Sharing Exception

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,188 @@
+JBGM LICENSE
+
+VERSION Xx420xX4, 05 May 2018
+
+Copyright � 2018 William Moodhe
+
+Anyone is allowed to copy, upload, or distribute copies of this license, but
+changing it is not allowed.
+
+Preamble
+
+The GNU license was garbage so I made my own. If you don't like it then feel
+free to delete the gamemode. A good portion of people have seen fit to modify
+stuff I've made, make it so people can "donate" for premium features, and
+subsequently generate revenue using things that I and others have created
+without permission. Then they ban members of my Steam groups, DDoS my own
+servers, openly insult me despite never having talked to me, and be jerks in
+general.
+
+So I will be issuing DMCA take down notices to server hosts and others who think
+that I'm joking. Server hosts have typically sided with me during the few times
+I've needed to do this. I don't plan on being 'that guy' and going after gmod
+servers trying to stay alive but I do plan on weeding out a few of the bigger
+jerks out there.
+
+tl;dr - I won't screw with you if you don't screw with me.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions
+
+"License" refers to this file.
+
+"Author" refers to the person William Moodhe <williammoodhe@gmail.com> 
+
+"Content" refers to all files and folders that the license came with as well as
+the intellectual property and all derivitive works.
+
+"Copyright" refers to the laws on intellectual property and the legal rights
+automatically granted to the Author during the creation of the Content.
+
+"Modify" refers to editing the Content as well as creating programs or code
+which depends on the Content to run. For the purpose of this license, deleting
+things without deleting the entire Content is ALSO considered editing.
+
+1. For any conditions not outlined in the License, refer to your country or
+state laws for Copyright. [Host your server in Russia.]
+
+2. You may freely copy, distribute, create derivitive works and distribute
+derivitive works of the Content as long as you obey the License and the License
+is not Modified. [Feel free to make edits.]
+
+3. You will not Modify the Content in such a way that it will, directly or
+indirectly, generate revenue without explicit, written permission from the
+Author. CLARIFICATION: This clause does not include cosmetic features such as
+hats, PointShop, etc. as long as it is not possible to purchase gameplay
+advantages. [For example: it is not allowed to make it so you can pay to have
+extra health, points, speed, etc. It is allowed to have revenue-generating
+addons that offer only cosmetics or features that do not change the gameplay.]
+
+4. You will not deny access to the Author to anything in such a way that it
+would not allow the Author to see if the Gamemode was Modified. [For example:
+banning my Steam groups from your server.]
+
+5. If you do not agree to any of the above conditions you must delete the
+Content in its entirety as well as all copies of the Content and derivitive
+works of the Content that you have made.
+
+END TERMS AND CONDITIONS
+
+Sharing Exception to the JBGM License
+Version 1, 12 Sep 2020
+
+Copyright © 2020 Rocky Breslow
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+We wanted to license our project under the GNU Affero General Public License
+(AGPLv3), however this license is incompatible with the JBGM License because the
+JBGM License places restrictions on commercial use.
+
+The main ideal we wish to inherit from AGPLv3 is for improvements made in
+alternate versions of the program to become available for other developers to
+incorporate.
+
+Our exception is designed specifically to ensure that, in such cases, the
+modified source code becomes available to the community. It requires the
+operator of a network server to provide the source code of the modified version
+running there to the users of that server. Therefore, public use of a modified
+version, on a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 1 of the Sharing Exception to JBGM License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works,
+such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License. Each
+licensee is addressed as "you". "Licensees" and "recipients" may be individuals
+or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a
+fashion requiring copyright permission, other than the making of an exact copy.
+The resulting work is called a "modified version" of the earlier work or a work
+"based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the
+Program.
+
+To "propagate" a work means to do anything with it that, without permission,
+would make you directly or secondarily liable for infringement under applicable
+copyright law, except executing it on a computer or modifying a private copy.
+Propagation includes copying, distribution (with or without modification),
+making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to
+make or receive copies. Mere interaction with a user through a computer network,
+with no transfer of a copy, is not conveying.
+
+1. Source Code.
+
+The "source code" for a work means the preferred form of the work for making
+modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard
+defined by a recognized standards body, or, in the case of interfaces specified
+for a particular programming language, one that is widely used among developers
+working in that language.
+
+The "System Libraries" of an executable work include anything, other than the
+work as a whole, that (a) is included in the normal form of packaging a Major
+Component, but which is not part of that Major Component, and (b) serves only to
+enable use of the work with that Major Component, or to implement a Standard
+Interface for which an implementation is available to the public in source code
+form.  A "Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system (if any) on
+which the executable work runs, or a compiler used to produce the work, or an
+object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source
+code needed to generate, install, and (for an executable work) run the object
+code and to modify the work, including scripts to control those activities.
+However, it does not include the work's System Libraries, or general-purpose
+tools or generally available free programs which are used unmodified in
+performing those activities but which are not part of the work.  For example,
+Corresponding Source includes interface definition files associated with source
+files for the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require, such as by
+intimate data communication or control flow between those subprograms and other
+parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate
+automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+3. Remote Network Interaction; Use with the JBGM License.
+
+Notwithstanding any other provision of the JGBM License, if you modify the
+program, your modified version must prominently offer all users interacting with
+it remotely through a computer network (if your version supports such
+interaction) an opportunity to receive the Corresponding Source of your version
+by providing access to the Corresponding Source from a network server at no
+charge, through some standard or customary means of facilitating copying of
+software. This Corresponding Source shall include the Corresponding Source for
+any work covered by version Xx420xX4 of the JBGM License that is incorporated
+pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link
+or combine any covered work with a work licensed under version Xx420xX4 of the
+JBGM License into a single combined work, and to convey the resulting work. The
+terms of this License will continue to apply to the part which is the covered
+work, but the work with which it is combined will remain governed by version
+Xx420xX4 of the JBGM License.
+
+END TERMS AND CONDITIONS

--- a/LICENSE
+++ b/LICENSE
@@ -166,7 +166,51 @@ automatically from other parts of the Corresponding Source.
 
 The Corresponding Source for a work in source code form is that same work.
 
-3. Remote Network Interaction; Use with the JBGM License.
+2. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you receive it,
+in any medium, provided that you conspicuously and appropriately publish on each
+copy an appropriate copyright notice; keep intact all notices stating that this
+License and any non-permissive terms added apply to the code; keep intact all
+notices of the absence of any warranty; and give all recipients a copy of this
+License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may
+offer support or warranty protection for a fee.
+
+3. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to produce it
+from the Program, in the form of source code under the terms of section 2,
+provided that you also meet all of these conditions:
+
+a) The work must carry prominent notices stating that you modified it, and
+giving a relevant date.
+
+b) The work must carry prominent notices stating that it is released under this
+License and any conditions added. This requirement modifies the requirement in
+section 2 to "keep intact all notices".
+
+c) You must license the entire work, as a whole, under this License to anyone
+who comes into possession of a copy. This License will therefore apply, along
+with any additional terms, to the whole of the work, and all its parts,
+regardless of how they are packaged. This License gives no permission to license
+the work in any other way, but it does not invalidate such permission if you
+have separately received it.
+
+d) If the work has interactive user interfaces, each must display Appropriate
+Legal Notices; however, if the Program has interactive interfaces that do not
+display Appropriate Legal Notices, your work need not make them do so. A
+compilation of a covered work with other separate and independent works, which
+are not by their nature extensions of the covered work, and which are not
+combined with it such as to form a larger program, in or on a volume of a
+storage or distribution medium, is called an "aggregate" if the compilation and
+its resulting copyright are not used to limit the access or legal rights of the
+compilation's users beyond what the individual works permit. Inclusion of a
+covered work in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+4. Remote Network Interaction; Use with the JBGM License.
 
 Notwithstanding any other provision of the JGBM License, if you modify the
 program, your modified version must prominently offer all users interacting with

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This repository contains a fork of [JetBoom's Zombie
 Survival](https://github.com/jetboom/zombiesurvival) gamemode for the "Hot Dad"
 Garry's Mod community.
 
+**_Licensing Note:_**
+
+With written permission from JetBoom, this repository is licensed under the JBGM
+License WITH the Sharing Exception.
+
+Our exception requires that, if you use any of our source code, you will make
+the source code of your version accessible to your players.
+
+If you want to use the improvements we _share_ with the community, you will have
+to give back as well.
+
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
   - [Maps](#maps)


### PR DESCRIPTION
## Overview

I wanted to license our repository under [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.en.html), specifically so that folks who use our source code will have to share improvements back with the community. I asked JetBoom if this was possible and he [stated](https://github.com/rbreslow/zs/files/5213305/Licensing.Qs.for.Zombie.Survival.eml.zip):

> As long as it doesn't override or conflict with the existing license anything is fine.

However, section 7 of the AGPLv3 states:

> All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.

The JBGM License contains terms disallowing commercial use, which I'd consider a further restriction to AGPLv3, so I don't think it's possible to relicense entirely under AGPLv3.

This PR is an experiment in designing an exception to the JBGM License that incorporates the specific terms related to source conveyance from AGPLv3.

Other examples of license exceptions, although most of these provide additional freedoms vs. impose additional restrictions:

- https://github.com/WebAssembly/wasi-sdk/pull/100
- https://spdx.org/licenses/exceptions-index.html

## Testing Instructions

N/A.

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
