### PR TITLE
Removed Skill backpeddler, removed backpeddling penalty

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend_sv.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend_sv.lua
@@ -182,10 +182,6 @@ function meta:ProcessDamage(dmginfo)
 				if self.MeleeDamageTakenMul and not dmgbypass then
 					dmginfo:SetDamage(dmginfo:GetDamage() * self.MeleeDamageTakenMul)
 				end
-
-				if self:IsSkillActive(SKILL_BACKPEDDLER) then
-					self:AddLegDamage(8)
-				end
 			end
 
 			if self.HasHemophilia and (damage >= 4 and dmgtype == 0 or bit.band(dmgtype, DMG_TAKE_BLEED) ~= 0) then

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/player_movement/shared/player_movement.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/player_movement/shared/player_movement.lua
@@ -39,16 +39,6 @@ function GM:Move(pl, move)
 			-- Use 7, because friction will amount this to a velocity of 1 roughly.
 			phase = pt.NoGhosting and E_GetDTFloat(pl, DT_PLAYER_FLOAT_WIDELOAD) > curtime()
 			M_SetMaxClientSpeed(move, math_min(M_GetMaxClientSpeed(move), phase and 7 or (36 * (pt.BarricadePhaseSpeedMul or 1))))
-		elseif not pt.NoBWSpeedPenalty then
-			fw = M_GetForwardSpeed(move)
-			if fw < 0 then
-				sd = M_GetSideSpeed(move)
-				if sd < 0 then sd = -sd end
-
-				if sd > fw then
-					M_SetMaxClientSpeed(move, M_GetMaxClientSpeed(move) * (P_GetActiveWeapon(pl).IsMelee and 0.75 or 0.5))
-				end
-			end
 		end
 	else
 		if pt.SpawnProtection then

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/skillweb/registry.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/skillweb/registry.lua
@@ -104,7 +104,6 @@ SKILL_SPEED2 = 2
 SKILL_SPEED3 = 3
 SKILL_SPEED4 = 4
 SKILL_SPEED5 = 5
-SKILL_BACKPEDDLER = 18
 SKILL_LOADEDHULL = 20
 SKILL_REINFORCEDHULL = 21
 SKILL_REINFORCEDBLADES = 22
@@ -409,7 +408,7 @@ GM:AddSkill(SKILL_SPEED3, "Speed III", GOOD.."+3 movement speed\n"..BAD.."-4 max
 GM:AddSkill(SKILL_SPEED4, "Speed IV", GOOD.."+4.5 movement speed\n"..BAD.."-6 maximum health",
 																-4,			0,					{SKILL_SPEED5, SKILL_SAFEFALL}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_SPEED5, "Speed V", GOOD.."+5.25 movement speed\n"..BAD.."-7 maximum health",
-																-4,			-2,					{SKILL_ULTRANIMBLE, SKILL_BACKPEDDLER, SKILL_MOTIONI, SKILL_CARDIOTONIC, SKILL_UNBOUND}, TREE_SPEEDTREE)
+																-4,			-2,					{SKILL_ULTRANIMBLE, SKILL_MOTIONI, SKILL_CARDIOTONIC, SKILL_UNBOUND}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_AGILEI, "Agile I", GOOD.."+4% jumping power\n"..BAD.."-2 movement speed",
 																4,			6,					{SKILL_NONE, SKILL_AGILEII}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_AGILEII, "Agile II", GOOD.."+5% jumping power\n"..BAD.."-3 movement speed",
@@ -424,8 +423,6 @@ GM:AddSkill(SKILL_MOTIONII, "Motion II", GOOD.."+0.75 movement speed",
 																-1,			-1,					{SKILL_MOTIONIII}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_MOTIONIII, "Motion III", GOOD.."+0.75 movement speed",
 																0,			-2,					{SKILL_D_SLOW}, TREE_SPEEDTREE)
-GM:AddSkill(SKILL_BACKPEDDLER, "Backpeddler", GOOD.."Move the same speed in all directions\n"..BAD.."-7 movement speed\n"..BAD.."Receive leg damage on any melee hit",
-																-6,			0,					{}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_PHASER, "Phaser", GOOD.."+15% barricade phasing movement speed\n"..BAD.."+15% sigil teleportation time",
 																-1,			4,					{SKILL_D_WIDELOAD, SKILL_DRIFT}, TREE_SPEEDTREE)
 GM:AddSkill(SKILL_DRIFT, "Drift", GOOD.."+5% barricade phasing movement speed",
@@ -1094,11 +1091,6 @@ GM:AddSkillModifier(SKILL_BARRICADEEXPERT, SKILLMOD_HAMMER_SWING_DELAY_MUL, 0.3)
 GM:AddSkillModifier(SKILL_SAFEFALL, SKILLMOD_FALLDAMAGE_DAMAGE_MUL, -0.4)
 GM:AddSkillModifier(SKILL_SAFEFALL, SKILLMOD_FALLDAMAGE_RECOVERY_MUL, -0.5)
 GM:AddSkillModifier(SKILL_SAFEFALL, SKILLMOD_FALLDAMAGE_SLOWDOWN_MUL, 0.4)
-
-GM:AddSkillModifier(SKILL_BACKPEDDLER, SKILLMOD_SPEED, -7)
-GM:AddSkillFunction(SKILL_BACKPEDDLER, function(pl, active)
-	pl.NoBWSpeedPenalty = active
-end)
 
 GM:AddSkillModifier(SKILL_D_CLUMSY, SKILLMOD_WORTH, 20)
 GM:AddSkillModifier(SKILL_D_CLUMSY, SKILLMOD_POINTS, 5)


### PR DESCRIPTION
## Overview

Removes the speed reduction received through backpeddling, removes the Backpeddling skill. Speed is now uniform in all directions

Resolves #20


## Testing Instructions

* Join a server as a human
* Notice that moving backwards/forwards/sideways are now the same movement speed
* Open the Skill tree (F3) and notice that Backpeddler is no longer available.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
