### PR TITLE
Set zs_colormod cvar as disabled by default

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/cl_postprocess.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/cl_postprocess.lua
@@ -16,7 +16,7 @@ cvars.AddChangeCallback("zs_filmgrainopacity", function(cvar, oldvalue, newvalue
 	GAMEMODE.FilmGrainOpacity = math.Clamp(tonumber(newvalue) or 0, 0, 255)
 end)
 
-GM.ColorModEnabled = CreateClientConVar("zs_colormod", "1", true, false):GetBool()
+GM.ColorModEnabled = CreateClientConVar("zs_colormod", "0", true, false):GetBool()
 cvars.AddChangeCallback("zs_colormod", function(cvar, oldvalue, newvalue)
 	GAMEMODE.ColorModEnabled = tonumber(newvalue) == 1
 end)


### PR DESCRIPTION
## Overview

Sets the F1 options 'Enable Color Mod' to disabled by default.

Fixes #8 

## Notes

* Will not affect users who already have this cvar set; as its value is stored.

## Testing Instructions

* Join the server for the first time (or having wiped client's info)
* Open F1 menu, select Options
* See that Enable Color Mod is not ticked.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
