### PR TITLE
Zombie replaces Fresh Dead, removed Agile Zombie from zombie select

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
@@ -3321,7 +3321,7 @@ function GM:ZombieKilledHuman(pl, attacker, inflictor, dmginfo, headshot, suicid
 			status:SetZombieInitializeTime(CurTime() + 2)
 		end
 
-		pl:SetZombieClassName(self.ZombieEscape and "Super Zombie" or self:IsClassicMode() and "Classic Zombie" or self:IsBabyMode() and "Gore Child" or "Fresh Dead")
+		pl:SetZombieClassName(self.ZombieEscape and "Super Zombie" or self:IsClassicMode() and "Classic Zombie" or self:IsBabyMode() and "Gore Child" or "Zombie")
 	end
 
 	gamemode.Call("PostZombieKilledHuman", pl, attacker, inflictor, dmginfo, headshot, suicide)

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/agiledead.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/agiledead.lua
@@ -10,6 +10,7 @@ CLASS.BetterVersion = "Fast Zombie"
 CLASS.SWEP = "weapon_zs_agiledead"
 
 CLASS.Unlocked = true
+CLASS.Hidden = true
 
 CLASS.Health = 125
 CLASS.Points = CLASS.Health/GM.NoHeadboxZombiePointRatio


### PR DESCRIPTION
## Overview

Humans killed become regular Zombies, not Fresh Dead. Agile Dead is no longer visible or selectable in the Zombie Selection menu.

Resolves #19 

## Notes

For visibility, when a human dies and rises as Zombie, they use the Zombie model, unlike before; Fresh Dead used the original humans model.

## Testing Instructions

*  Join a server with 1+ bots
*  Become mother zm. Kill a bot.
*  Bot will rise as a standard Zombie


* As a Zombie, open Selection menu (F3)
* Agile Dead is no longer available

## Checklist

- [x] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
