### PR TITLE
Make Stowage skill enabled by default

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/entities/entities/prop_resupplybox/cl_init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/entities/entities/prop_resupplybox/cl_init.lua
@@ -38,14 +38,20 @@ function ENT:RenderInfo(pos, ang, owner)
 	cam.Start3D2D(pos, ang, 0.075)
 		draw.SimpleText(translate.Get("resupply_box"), "ZS3D2DFont2", 0, -130, (MySelf.NextUse or 0) <= CurTime() and COLOR_GREEN or COLOR_DARKRED, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 
-		local caches = MySelf.Stowage and MySelf.StowageCaches
+		local caches = MySelf.StowageCaches
 
 		local timeremain = math.ceil(math.max(0, (MySelf.NextUse or 0) - CurTime()))
 		if MySelf.NextUse then
 			draw.SimpleText(timeremain > 0 and timeremain or translate.Get("ready"), "ZS3D2DFont2", 0, -60, (MySelf.NextUse or 0) <= CurTime() and COLOR_GREEN or COLOR_DARKRED, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 		end
 		if caches then
-			draw.SimpleText(caches .. " Uses Left", "ZS3D2DFont2Small", 0, 0, caches > 0 and COLOR_GREEN or COLOR_DARKRED, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+			local suffix = " Use Left"
+			if caches > 1 then
+				suffix = " Uses Left"
+			else
+
+			end
+			draw.SimpleText(caches .. suffix, "ZS3D2DFont2Small", 0, 0, caches > 0 and COLOR_GREEN or COLOR_DARKRED, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 		end
 
 		self:Draw3DHealthBar(math.Clamp(self:GetObjectHealth() / self:GetMaxObjectHealth(), 0, 1), nil, 190)

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/init.lua
@@ -1131,7 +1131,7 @@ function GM:Think()
 					pl.OldWeaponToReload = nil
 				end
 
-				if pl:IsSkillActive(SKILL_STOWAGE) and self:GetWave() > 0 and time > (pl.NextResupplyUse or 0) then
+				if self:GetWave() > 0 and time > (pl.NextResupplyUse or 0) then
 					local stockpiling = pl:IsSkillActive(SKILL_STOCKPILE)
 
 					pl.NextResupplyUse = time + self.ResupplyBoxCooldown * (pl.ResupplyDelayMul or 1) * (stockpiling and 2.12 or 1)

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend_sv.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/obj_player_extend_sv.lua
@@ -919,31 +919,22 @@ function meta:Resupply(owner, obj)
 	if GAMEMODE:GetWave() <= 0 then return end
 
 	local stockpiling = self:IsSkillActive(SKILL_STOCKPILE)
-	local stowage = self:IsSkillActive(SKILL_STOWAGE)
 
-	if (stowage and (self.StowageCaches or 0) <= 0) or (not stowage and CurTime() < (self.NextResupplyUse or 0)) then
+	if ((self.StowageCaches or 0) <= 0) then
 		self:CenterNotify(COLOR_RED, translate.ClientGet(self, "no_ammo_here"))
 		return
 	end
 
-	if not stowage then
-		self.NextResupplyUse = CurTime() + GAMEMODE.ResupplyBoxCooldown * (self.ResupplyDelayMul or 1) * (stockpiling and 2.12 or 1)
+	self.StowageCaches = self.StowageCaches - 1
 
-		net.Start("zs_nextresupplyuse")
-			net.WriteFloat(self.NextResupplyUse)
-		net.Send(self)
-	else
-		self.StowageCaches = self.StowageCaches - 1
-
-		net.Start("zs_stowagecaches")
-			net.WriteInt(self.StowageCaches, 8)
-		net.Send(self)
-	end
+	net.Start("zs_stowagecaches")
+		net.WriteInt(self.StowageCaches, 8)
+	net.Send(self)
 
 	local ammotype = self:GetResupplyAmmoType()
 	local amount = GAMEMODE.AmmoCache[ammotype]
 
-	for i = 1, stockpiling and not stowage and 2 or 1 do
+	for i = 1, stockpiling and 2 or 1 do
 		net.Start("zs_ammopickup")
 			net.WriteUInt(amount, 16)
 			net.WriteString(ammotype)

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/skillweb/registry.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/skillweb/registry.lua
@@ -244,7 +244,6 @@ SKILL_DRIFT = 142
 SKILL_WARP = 143
 SKILL_LEVELHEADED = 144
 SKILL_ROBUST = 145
-SKILL_STOWAGE = 146
 SKILL_TRUEWOOISM = 147
 SKILL_UNBOUND = 148
 
@@ -540,7 +539,7 @@ GM:AddSkill(SKILL_LIGHTCONSTRUCT, "Light Construction", GOOD.."-25% deployable p
 GM:AddSkill(SKILL_STOCKPILE, "Stockpiling", GOOD.."Collect twice as much from resupplies\n"..BAD.."2.12x resupply box delay",
 																8,			-3,					{}, TREE_BUILDINGTREE)
 GM:AddSkill(SKILL_ACUITY, "Supplier's Acuity", GOOD.."Locate nearby resupply boxes if behind walls\n"..GOOD.."Locate nearby unplaced resupply boxes on players through walls\n"..GOOD.."Locate nearby resupply packs through walls",
-																6,			-3,					{SKILL_INSIGHT, SKILL_STOCKPILE, SKILL_U_CRAFTINGPACK, SKILL_STOWAGE}, TREE_BUILDINGTREE)
+																6,			-3,					{SKILL_INSIGHT, SKILL_STOCKPILE, SKILL_U_CRAFTINGPACK}, TREE_BUILDINGTREE)
 GM:AddSkill(SKILL_VISION, "Refiner's Vision", GOOD.."Locate nearby remantlers if behind walls\n"..GOOD.."Locate nearby unplaced remantlers on players through walls",
 																6,			-6,					{SKILL_NONE, SKILL_ACUITY}, TREE_BUILDINGTREE)
 GM:AddSkill(SKILL_U_ROCKETTURRET, "Unlock: Rocket Turret", GOOD.."Unlocks purchasing the Rocket Turret\nFires explosives instead of SMG ammo\nDeals damage in a radius\nHigh tier deployable",
@@ -562,8 +561,6 @@ GM:AddSkill(SKILL_D_NOODLEARMS, "Debuff: Noodle Arms", GOOD.."+5 starting Worth\
 																-7,			2,					{}, TREE_BUILDINGTREE)
 GM:AddSkill(SKILL_INSTRUMENTS, "Instruments", GOOD.."+5% turret range",
 																-10,		-3,					{}, TREE_BUILDINGTREE)
-GM:AddSkill(SKILL_STOWAGE, 	"Stowage", GOOD.."Resupply usages build up when you're not there\n"..BAD.."+15% resupply delay",
-																4,			-3,					{}, TREE_BUILDINGTREE)
 
 -- Gunnery Tree
 GM:AddSkill(SKILL_TRIGGER_DISCIPLINE1, "Trigger Discipline I", GOOD.."+2% weapon reload speed\n"..GOOD.."+2% weapon draw speed",
@@ -1253,11 +1250,6 @@ GM:AddSkillModifier(SKILL_ROBUST, SKILLMOD_WEAPON_WEIGHT_SLOW_MUL, -0.06)
 GM:AddSkillModifier(SKILL_TAUT, SKILLMOD_PROP_CARRY_SLOW_MUL, 0.4)
 
 GM:AddSkillModifier(SKILL_TURRETOVERLOAD, SKILLMOD_TURRET_RANGE_MUL, -0.3)
-
-GM:AddSkillModifier(SKILL_STOWAGE, SKILLMOD_RESUPPLY_DELAY_MUL, 0.15)
-GM:AddSkillFunction(SKILL_STOWAGE, function(pl, active)
-	pl.Stowage = active
-end)
 
 GM:AddSkillFunction(SKILL_TRUEWOOISM, function(pl, active)
 	pl.TrueWooism = active


### PR DESCRIPTION
## Overview

Stockpiles resupply uses instead of storing at most 1 use. Removes Stowage skill as it is now redundant.

Resolves #5 

## Demo

1 use:
![Screenshot 2020-09-16 at 14 59 54](https://user-images.githubusercontent.com/3932269/93298279-ebb5d300-f82d-11ea-99aa-81db3e2946ec.png)
2+ uses
![Screenshot 2020-09-16 at 15 00 13](https://user-images.githubusercontent.com/3932269/93298283-ee182d00-f82d-11ea-8cb8-e2867dd77b88.png)

## Notes

I also corrected the grammar for when there is exactly 1 use

## Testing Instructions

If familiar with the Stowage skill, the behaviour is identical, otherwise:
* Join the server as a human
* Ensure a resupply is placed
* Wait for 61+ seconds after wave 1 starts. For every 60 seconds the use count displayed on the resupply will increment by 1
* Each use of the resupply will reduce the count by 1 until 0 uses remain

## Checklist

- [x] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
