### PR TITLE
Replaced standard zombie's model and run animations

### DIFF
--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/zombie.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/zombie.lua
@@ -20,7 +20,7 @@ CLASS.Points = CLASS.Health/GM.HumanoidZombiePointRatio
 
 CLASS.SWEP = "weapon_zs_zombie"
 
-CLASS.Model = Model("models/player/zombie_classic_hbfix.mdl")
+CLASS.UsePlayerModel = true
 
 CLASS.PainSounds = {"npc/zombie/zombie_pain1.wav", "npc/zombie/zombie_pain2.wav", "npc/zombie/zombie_pain3.wav", "npc/zombie/zombie_pain4.wav", "npc/zombie/zombie_pain5.wav", "npc/zombie/zombie_pain6.wav"}
 CLASS.DeathSounds = {"npc/zombie/zombie_die1.wav", "npc/zombie/zombie_die2.wav", "npc/zombie/zombie_die3.wav"}
@@ -151,7 +151,7 @@ function CLASS:CalcMainActivity(pl, velocity)
 		return ACT_HL2MP_WALK_CROUCH_ZOMBIE_01 - 1 + math_ceil((CurTime() / 4 + pl:EntIndex()) % 3), -1
 	end
 
-	return ACT_HL2MP_WALK_ZOMBIE_01 - 1 + math_ceil((CurTime() / 3 + pl:EntIndex()) % 3), -1
+	return ACT_HL2MP_RUN_ZOMBIE, -1
 end
 
 function CLASS:UpdateAnimation(pl, velocity, maxseqgroundspeed)
@@ -282,5 +282,13 @@ if SERVER then
 end
 
 if CLIENT then
-	CLASS.Icon = "zombiesurvival/killicons/zombie"
+	CLASS.Icon = "zombiesurvival/killicons/fresh_dead"
+
+	function CLASS:PrePlayerDraw(pl)
+		render.SetColorModulation(0.5, 0.9, 0.5)
+	end
+
+	function CLASS:PostPlayerDraw(pl)
+		render.SetColorModulation(1, 1, 1)
+	end
 end

--- a/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/zombie_gore_blaster.lua
+++ b/src/garrysmod/gamemodes/zombiesurvival/gamemode/zombieclasses/zombie_gore_blaster.lua
@@ -13,6 +13,7 @@ CLASS.Unlocked = true
 CLASS.Health = 220
 CLASS.Speed = 180
 CLASS.Revives = false
+CLASS.Model = Model("models/player/zombie_classic_hbfix.mdl")
 
 CLASS.Points = CLASS.Health/GM.HumanoidZombiePointRatio
 


### PR DESCRIPTION
## Overview

* Replaces the standard zombie player model with the old agile dead-style appearance (i.e. uses the player's model).
* Replaces the default zombie running animations with the butchers

Resolves #18 

## Demo

![Screenshot 2020-09-16 at 18 42 33](https://user-images.githubusercontent.com/3932269/93327151-e15aff80-f854-11ea-972b-8c7dce486a8c.png)


## Notes

Goreblaster Zombie extends the Standard Zombie, but retains the old zombie model as it uses a reskin that isn't designed for other models. It will use the butcher animations

## Testing Instructions

* Join the server
* Become a zombie (and make sure you are a Standard Zombie)
* See that the rendered model in 3rd person is your chosen human model.
* See that the running animation is no longer janky and uses the smoother butcher animation with raised arms
* Switch to Goreblaster Zombie
* See that the player model is unchanged, but the running animation is also the butcher animation

## Checklist

- [x] `fixup!` commits have been squashed
- [x] README.md updated if necessary to reflect the changes
